### PR TITLE
chore: QueryDSL 설정 및 BaseEntity 정의

### DIFF
--- a/src/main/java/com/pintor/dev/jigeumiyag/JigeumiyagApplication.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/JigeumiyagApplication.java
@@ -2,7 +2,9 @@ package com.pintor.dev.jigeumiyag;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class JigeumiyagApplication {
 

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/config/QuerydslConfig.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.pintor.dev.jigeumiyag.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/entity/BaseEntity.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.pintor.dev.jigeumiyag.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @Builder.Default
+    @Column(columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID id = UUID.randomUUID();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/entity/BaseUpdatableEntity.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/entity/BaseUpdatableEntity.java
@@ -1,0 +1,24 @@
+package com.pintor.dev.jigeumiyag.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.Instant;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+public abstract class BaseUpdatableEntity extends BaseEntity {
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private Instant updatedAt;
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #4

## PR 유형
- [x] chore: 빌드·설정 변경

## 작업 내용
- QuerydslConfig: JPAQueryFactory 빈 등록
- BaseEntity: UUID PK(@Builder.Default), createdAt(@CreatedDate)
- BaseUpdatableEntity: updatedAt(@LastModifiedDate)
- @EnableJpaAuditing 적용

## 테스트 내용
- [x] 로컬 테스트 완료

## 체크리스트
- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [ ] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트
- BaseEntity @Builder.Default UUID 생성 방식 확인

## 스크린샷 / 참고 자료
- 해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터 추적 및 감시 기능 인프라 구축
  * 데이터 조회 성능 최적화를 위한 설정 추가
  * 공통 엔티티 기본 구조 개선으로 코드 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->