### PR TITLE
feat: 공통 예외 계층 구현 (ApiException, ErrorCode, GlobalExceptionHandler)

### DIFF
--- a/src/main/java/com/pintor/dev/jigeumiyag/global/common/dto/ErrorResponse.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/common/dto/ErrorResponse.java
@@ -1,5 +1,7 @@
 package com.pintor.dev.jigeumiyag.global.common.dto;
 
+import com.pintor.dev.jigeumiyag.global.exception.common.ErrorCode;
+
 import java.util.Map;
 
 public record ErrorResponse(
@@ -9,11 +11,11 @@ public record ErrorResponse(
         Map<String, String> details
 ) {
 
-    public static ErrorResponse of(int status, String code, String message) {
-        return new ErrorResponse(status, code, message, null);
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage(), null);
     }
 
-    public static ErrorResponse of(int status, String code, String message, Map<String, String> details) {
-        return new ErrorResponse(status, code, message, details);
+    public static ErrorResponse of(ErrorCode errorCode, Map<String, String> details) {
+        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage(), details);
     }
 }

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/exception/common/ApiException.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/exception/common/ApiException.java
@@ -1,0 +1,14 @@
+package com.pintor.dev.jigeumiyag.global.exception.common;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/exception/common/ErrorCode.java
@@ -1,0 +1,57 @@
+package com.pintor.dev.jigeumiyag.global.exception.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    COMMON_UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 오류가 발생했습니다."),
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_002", "요청한 리소스를 찾을 수 없습니다."),
+    COMMON_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_003", "지원하지 않는 HTTP 메서드입니다."),
+    COMMON_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "COMMON_004", "잘못된 요청 형식입니다."),
+    COMMON_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_005", "잘못된 요청입니다."),
+    COMMON_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_006", "인증이 필요합니다."),
+    COMMON_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_007", "권한이 없습니다."),
+
+    // Auth
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_001", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 만료되었습니다."),
+    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 토큰입니다."),
+    AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_004", "Refresh Token이 만료되었습니다."),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_005", "권한이 없습니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "유저를 찾을 수 없습니다."),
+    EMAIL_DUPLICATE(HttpStatus.CONFLICT, "USER_002", "이미 사용 중인 이메일입니다."),
+    NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "USER_003", "이미 사용 중인 닉네임입니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER_004", "이메일 인증이 필요합니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USER_005", "비밀번호가 일치하지 않습니다."),
+
+    // Product
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_001", "상품을 찾을 수 없습니다."),
+    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "PRODUCT_002", "재고가 부족합니다."),
+
+    // Order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_001", "주문을 찾을 수 없습니다."),
+    ORDER_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "ORDER_002", "결제 금액이 일치하지 않습니다."),
+    ORDER_CANCEL_UNAVAILABLE(HttpStatus.BAD_REQUEST, "ORDER_003", "취소할 수 없는 주문 상태입니다."),
+
+    // Cart
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CART_001", "장바구니 항목을 찾을 수 없습니다."),
+
+    // Board
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "게시글을 찾을 수 없습니다."),
+    BOARD_SELF_VOTE(HttpStatus.BAD_REQUEST, "BOARD_002", "본인 글은 추천할 수 없습니다."),
+
+    // File
+    FILE_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FILE_001", "허용되지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE_002", "파일 크기가 초과되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/exception/handler/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
         log.warn("[ApiException] {} status: {}, code: {}, message: {}",
                 errorCode.name(), errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode)));
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
         log.warn("[NoResourceFound] status: {}, code: {}, message: {}",
                 errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode)));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
         log.warn("[MethodNotSupported] status: {}, code: {}, message: {}",
                 errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode)));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
@@ -58,19 +58,20 @@ public class GlobalExceptionHandler {
         log.warn("[MessageNotReadable] status: {}, code: {}, message: {}",
                 errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
         return ResponseEntity.badRequest()
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode)));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
         ErrorCode errorCode = COMMON_INVALID_REQUEST;
-        String detail = String.format("%s: %s 타입이어야 합니다.",
+        Map<String, String> details = Map.of(
                 e.getName(),
-                e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown");
-        log.warn("[ArgumentTypeMismatch] status: {}, code: {}, detail: {}",
-                errorCode.getStatus().value(), errorCode.getCode(), detail);
+                String.format("%s 타입이어야 합니다.", e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown")
+        );
+        log.warn("[ArgumentTypeMismatch] status: {}, code: {}, details: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), details);
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), detail)));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode, details)));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -85,7 +86,7 @@ public class GlobalExceptionHandler {
         log.warn("[ArgumentNotValid] status: {}, code: {}, details: {}",
                 errorCode.getStatus().value(), errorCode.getCode(), details);
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), "입력값이 유효하지 않습니다.", details)));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode, details)));
     }
 
     @ExceptionHandler(ClientAbortException.class)
@@ -100,6 +101,6 @@ public class GlobalExceptionHandler {
                 e.getClass().getSimpleName(),
                 e.getCause() != null ? e.getCause().getMessage() : e.getMessage(), e);
         return ResponseEntity.internalServerError()
-                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode)));
     }
 }

--- a/src/main/java/com/pintor/dev/jigeumiyag/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,105 @@
+package com.pintor.dev.jigeumiyag.global.exception.handler;
+
+import com.pintor.dev.jigeumiyag.global.common.dto.ApiResponse;
+import com.pintor.dev.jigeumiyag.global.common.dto.ErrorResponse;
+import com.pintor.dev.jigeumiyag.global.exception.common.ApiException;
+import com.pintor.dev.jigeumiyag.global.exception.common.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.pintor.dev.jigeumiyag.global.exception.common.ErrorCode.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleApiException(ApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("[ApiException] {} status: {}, code: {}, message: {}",
+                errorCode.name(), errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleNoResourceFound(NoResourceFoundException e) {
+        ErrorCode errorCode = COMMON_NOT_FOUND;
+        log.warn("[NoResourceFound] status: {}, code: {}, message: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        ErrorCode errorCode = COMMON_METHOD_NOT_ALLOWED;
+        log.warn("[MethodNotSupported] status: {}, code: {}, message: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        ErrorCode errorCode = COMMON_MESSAGE_NOT_READABLE;
+        log.warn("[MessageNotReadable] status: {}, code: {}, message: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorCode errorCode = COMMON_INVALID_REQUEST;
+        String detail = String.format("%s: %s 타입이어야 합니다.",
+                e.getName(),
+                e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown");
+        log.warn("[ArgumentTypeMismatch] status: {}, code: {}, detail: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), detail);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), detail)));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleValidationException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = COMMON_INVALID_REQUEST;
+        Map<String, String> details = e.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(
+                        FieldError::getField,
+                        field -> field.getDefaultMessage() != null ? field.getDefaultMessage() : "유효하지 않은 값입니다.",
+                        (existing, replacement) -> existing
+                ));
+        log.warn("[ArgumentNotValid] status: {}, code: {}, details: {}",
+                errorCode.getStatus().value(), errorCode.getCode(), details);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), "입력값이 유효하지 않습니다.", details)));
+    }
+
+    @ExceptionHandler(ClientAbortException.class)
+    public void handleClientAbort(ClientAbortException e) {
+        log.warn("[ClientAbort] message: {}", e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleException(Exception e) {
+        ErrorCode errorCode = COMMON_UNEXPECTED_ERROR;
+        log.error("[UnexpectedException] cause: {}, message: {}",
+                e.getClass().getSimpleName(),
+                e.getCause() != null ? e.getCause().getMessage() : e.getMessage(), e);
+        return ResponseEntity.internalServerError()
+                .body(ApiResponse.fail(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+}


### PR DESCRIPTION

## 관련 이슈

- Closes #7

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `ErrorCode` enum: `HttpStatus` 타입 status 필드로 공통/도메인별 에러코드 일괄 관리
- `ApiException`: 도메인 예외가 직접 상속하는 추상 클래스
- `GlobalExceptionHandler`: 공통 예외 처리 (ApiException, Validation, TypeMismatch, MethodNotSupported, MessageNotReadable, NoResourceFound, ClientAbort, Exception)
- `ErrorResponse.of()`: `ErrorCode`를 직접 받아 status/code/message 추출

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- `ErrorResponse`가 `ErrorCode`를 직접 받는 방식의 적절성
- `MethodArgumentTypeMismatchException` 단일 `Map.of` 처리 방식

## 스크린샷 / 참고 자료

- 해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * API 에러 응답 처리 체계를 표준화하여 모든 에러에 일관된 형식으로 응답합니다.
  * 전역 예외 처리를 통해 예상치 못한 에러와 라우팅 에러를 일관되게 처리합니다.
  * 요청 유효성 검사 실패 시 필드별 상세한 에러 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->