### PR TITLE
feat: Security 기본 뼈대 설정 (CORS, CSRF, 경로 권한 구성)

### DIFF
--- a/src/main/java/com/pintor/dev/jigeumiyag/global/config/SecurityConfig.java
+++ b/src/main/java/com/pintor/dev/jigeumiyag/global/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.pintor.dev.jigeumiyag.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private static final String[] PUBLIC_GET_URLS = {
+            "/api/products/**",
+            "/api/boards/**",
+    };
+
+    private static final String[] PUBLIC_POST_URLS = {
+            "/api/auth/login",
+            "/api/auth/refresh",
+            "/api/users/register",
+    };
+
+    private static final String[] ADMIN_URLS = {
+            "/api/admin/**",
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/api/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()
+                        .requestMatchers(HttpMethod.POST, PUBLIC_POST_URLS).permitAll()
+                        .requestMatchers(ADMIN_URLS).hasRole("ADMIN")
+                        // TODO: Phase 1 - JWT 필터 연결 후 아래 주석 해제
+                        // .anyRequest().authenticated()
+                        .anyRequest().permitAll()
+                )
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(formLogin -> formLogin.disable())
+        ;
+        // TODO: Phase 1 - JWT 필터 추가
+        // .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173", "https://jigumiyag.pintor.dev"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION

## 관련 이슈

- Closes #8

## PR 유형

- [x] feat: 새로운 기능

## 작업 내용

- `SecurityConfig`: Stateless 세션, CSRF/httpBasic/formLogin 비활성화
- CORS 설정 (허용 origin/method/header/exposed-header)
- 경로별 권한 뼈대 구성 (공개 GET/POST, 관리자 전용, 인증 필요)
- Phase 1 JWT 필터 자리 주석 확보

## 테스트 내용

- [x] 로컬 테스트 완료

## 체크리스트

- [x] 셀프 리뷰를 완료했습니다.
- [x] 코드 컨벤션을 지켰습니다.
- [ ] API 변경 사항이 Swagger에 반영되어 있습니다.
- [x] 공통 응답 포맷 및 공통 유틸을 사용했습니다.
- [x] API 키, 비밀번호 등 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 주석 및 디버그 코드를 제거했습니다.

## 리뷰 포인트

- 경로 권한 뼈대 구성의 적절성 (Phase 1에서 경로 확정 예정)
- CORS 허용 origin 범위

## 스크린샷 / 참고 자료

- 해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 강화**
  * API 엔드포인트에 대한 보안 정책 적용
  * 공개 엔드포인트에 대한 인증 없는 접근 허용
  * 관리자 기능 접근 제한 구현
  * CORS 설정 추가 (개발/프로덕션 환경 지원)
  * 세션 무상태 관리 및 비밀번호 암호화 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->